### PR TITLE
Dogfooding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Is It Maintained?
 
+[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/mnapoli/IsItMaintained.svg)](http://isitmaintained.com/project/mnapoli/IsItMaintained "Average time to resolve an issue")
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/mnapoli/IsItMaintained.svg)](http://isitmaintained.com/project/mnapoli/IsItMaintained "Percentage of issues still open")
+
 Monitoring open source projects activity.
 
 ![](web/img/dude.png)


### PR DESCRIPTION
> Eating your own dog food, also called dogfooding, is a slang term used to reference a scenario in which a company uses its own product to test and promote the product.
> / Wikipedia

:D