### PR TITLE
Change google fonts to https

### DIFF
--- a/res/views/layout.twig
+++ b/res/views/layout.twig
@@ -17,8 +17,8 @@
     <link href="/css/theme.css" rel="stylesheet">
 
     <link href="/vendor/fontawesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 
     <script src="/vendor/jquery/dist/jquery.min.js"></script>
 


### PR DESCRIPTION
This changes http://fonts.googleapis.com to https://fonts.googleapis.com

This fixes an issue where Chrome complains about Mixed Content when visiting [/project/markedjs/marked](https://isitmaintained.com/project/markedjs/marked)

> marked:12 Mixed Content: The page at 'https://isitmaintained.com/project/markedjs/marked' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Montserrat:400,700'. This request has been blocked; the content must be served over HTTPS.