### PR TITLE
Replace PhantomJS with React Native

### DIFF
--- a/src/Maintained/Application/Controller/HomeController.php
+++ b/src/Maintained/Application/Controller/HomeController.php
@@ -40,7 +40,7 @@ class HomeController
             'angular/angular.js'     => 'AngularJS',
             'meteor/meteor'          => 'Meteor',
             'facebook/react'         => 'React',
-            'ariya/phantomjs'        => 'PhantomJS',
+            'facebook/react-native'  => 'React Native',
             'gulpjs/gulp'            => 'Gulp',
             'robbyrussell/oh-my-zsh' => 'Oh My Zsh',
         ];


### PR DESCRIPTION
PhantomJS comes end of life so we should replace it with something else.
I thought React Native is popular enough.